### PR TITLE
AWS Utilities to retrieve instance ID and metadata

### DIFF
--- a/awsutils/awsutils.go
+++ b/awsutils/awsutils.go
@@ -27,9 +27,9 @@ func getValue(uri string) (string, error) {
 		return "", err
 	}
 
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint
 
-	body, err := ioutil.ReadAll(resp.Body) //nolint
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Basic utils to retrieve instance metadata from an AMI. Will be used for auto-registration.