### PR TITLE
try to increase gometalinter deadline to avoid deadline exceeded errors

### DIFF
--- a/magetask/common.go
+++ b/magetask/common.go
@@ -129,7 +129,7 @@ func Lint() error {
 		"--enable",
 		"staticcheck",
 		"--deadline",
-		"15m",
+		"30m",
 		"--tests",
 		"./...",
 	); err != nil {


### PR DESCRIPTION
Getting tired of havingt the following issues while building services:

```
WARNING: deadline exceeded by linter structcheck (try increasing --deadline)
WARNING: deadline exceeded by linter gosimple (try increasing --deadline)
WARNING: deadline exceeded by linter staticcheck (try increasing --deadline)
WARNING: deadline exceeded by linter varcheck (try increasing --deadline)
WARNING: deadline exceeded by linter errcheck (try increasing --deadline)
```
Try inscreasing `--deadline` from 5m to 15m