### PR TITLE
Fixed: Simplify unit testing so it properly fails on error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,11 +31,7 @@ lint:
 		./...
 
 test:
-	@ echo 'mode: atomic' > unit_coverage.cov
-	@ for d in $(shell go list ./... | grep -v vendor); do \
-		go test -race -coverprofile=profile.out -covermode=atomic "$$d"; \
-		if [ -f profile.out ]; then tail -q -n +2 profile.out >> unit_coverage.cov; rm -f profile.out; fi; \
-	done;
+	@ go test ./... -race -cover -covermode=atomic -coverprofile=unit_coverage.cov
 
 coverage_aggregate:
 	@ mkdir -p artifacts


### PR DESCRIPTION
#### Description
Libraries incorrectly skip over failures in unit tests. This should fix it.