### PR TITLE
fix log rotation

### DIFF
--- a/logutils/log.go
+++ b/logutils/log.go
@@ -131,7 +131,7 @@ func NewLogger(serviceName string, level string, format string, file string, fil
 		config.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	}
 
-	logger := InitLogger(w, config)
+	logger := initLogger(w, config)
 
 	if err != nil {
 		panic(err)
@@ -140,8 +140,8 @@ func NewLogger(serviceName string, level string, format string, file string, fil
 	return logger, config
 }
 
-// InitLogger constructs the logger from the options
-func InitLogger(w zapcore.WriteSyncer, conf zap.Config) *zap.Logger {
+// initLogger constructs the logger from the options
+func initLogger(w zapcore.WriteSyncer, conf zap.Config) *zap.Logger {
 	var enc zapcore.Encoder
 	var coreFile zapcore.Core
 

--- a/logutils/log.go
+++ b/logutils/log.go
@@ -131,10 +131,8 @@ func NewLogger(serviceName string, level string, format string, file string, fil
 		config.Level = zap.NewAtomicLevelAt(zap.InfoLevel)
 	}
 
-	logger, err := config.Build()
-	if w != nil {
-		logger, err = config.Build(SetOutput(w, config))
-	}
+	logger := InitLogger(w, config)
+
 	if err != nil {
 		panic(err)
 	}
@@ -142,10 +140,11 @@ func NewLogger(serviceName string, level string, format string, file string, fil
 	return logger, config
 }
 
-// SetOutput returns the zap option with the new sync writer
-func SetOutput(w zapcore.WriteSyncer, conf zap.Config) zap.Option {
+// InitLogger constructs the logger from the options
+func InitLogger(w zapcore.WriteSyncer, conf zap.Config) *zap.Logger {
 	var enc zapcore.Encoder
-	// Copy paste from zap.Config.buildEncoder.
+	var coreFile zapcore.Core
+
 	switch conf.Encoding {
 	case "json":
 		enc = zapcore.NewJSONEncoder(conf.EncoderConfig)
@@ -154,13 +153,27 @@ func SetOutput(w zapcore.WriteSyncer, conf zap.Config) zap.Option {
 	default:
 		panic("unknown encoding")
 	}
-	return zap.WrapCore(func(zapcore.Core) zapcore.Core {
-		return zapcore.NewCore(enc, w, conf.Level)
-	})
+
+	console := zapcore.Lock(os.Stdout)
+	coreConsole := zapcore.NewCore(enc, console, conf.Level)
+
+	if w != nil {
+		coreFile = zapcore.NewCore(enc, w, conf.Level)
+	}
+
+	core := zapcore.NewTee(
+		coreFile,
+		coreConsole,
+	)
+
+	logger := zap.New(core)
+	return logger
 }
 
 // handleOutputFile handles options in log configs to redirect to file
 func handleOutputFile(config *zap.Config, file string, fileOnly bool) (zapcore.WriteSyncer, error) {
+
+	var w zapcore.WriteSyncer
 
 	if file == "" {
 		return nil, nil
@@ -172,17 +185,20 @@ func handleOutputFile(config *zap.Config, file string, fileOnly bool) (zapcore.W
 		}
 	}
 
-	if fileOnly {
-		w := zapcore.AddSync(&lumberjack.Logger{
+	if file != "" {
+		w = zapcore.AddSync(&lumberjack.Logger{
 			Filename:   file,
 			MaxSize:    logFileSizeDefault,
 			MaxBackups: logFileNumBackups,
 			MaxAge:     logFileAge,
 		})
-		config.OutputPaths = []string{file}
-		return w, nil
 	}
 
-	config.OutputPaths = append(config.OutputPaths, file)
-	return nil, nil
+	if fileOnly {
+		config.OutputPaths = []string{file}
+	} else {
+		config.OutputPaths = append(config.OutputPaths, file)
+	}
+
+	return w, nil
 }


### PR DESCRIPTION
Log rotation was broken when we want to log on both the file and console. 

==========
Testing Done
==========
Tested enforcer with custom log line in a loop. The file in /var/log/enforcerd at 10MB was backed up with the timestamp and a new file was used to write logs. 
