### PR TITLE
new helper that uses supplied app credential to provision app credential - deprecate existing API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ testresults.xml
 *.lock
 vendor
 *.cov
+.idea
 artifacts
 profile.out

--- a/appcreds/appcreds.go
+++ b/appcreds/appcreds.go
@@ -34,32 +34,32 @@ func New(ctx context.Context, m manipulate.Manipulator, namespace string, name s
 	return NewWithAppCredential(ctx, m, creds)
 }
 
-// NewFromTemplate generates a new CSR for the provided app credential and calls the upstream service using the supplied
+// Create generates a new CSR for the provided app credential and calls the upstream service using the supplied
 // manipulator to provision the app credential. The returned credential will have the private key used to generate the CSR
 // added back as an attribute. An error and a nil app cred reference is returned if CSR generation or the API call to the
 // upstream service failed.
-func NewFromTemplate(ctx context.Context, m manipulate.Manipulator, template *gaia.AppCredential) (*gaia.AppCredential, error) {
+func Create(ctx context.Context, m manipulate.Manipulator, ac *gaia.AppCredential) (*gaia.AppCredential, error) {
 
 	csr, pk, err := makeCSR()
 	if err != nil {
 		return nil, err
 	}
 
-	template.CSR = string(csr)
+	ac.CSR = string(csr)
 
-	if err := m.Create(manipulate.NewContext(ctx, manipulate.ContextOptionNamespace(template.Namespace)), template); err != nil {
+	if err := m.Create(manipulate.NewContext(ctx, manipulate.ContextOptionNamespace(ac.Namespace)), ac); err != nil {
 		return nil, err
 	}
 
-	template.Credentials.CertificateKey = base64.StdEncoding.EncodeToString(pk)
+	ac.Credentials.CertificateKey = base64.StdEncoding.EncodeToString(pk)
 
-	return template, nil
+	return ac, nil
 }
 
 // NewWithAppCredential creates a new *gaia.AppCredential from an *AppCredential
-// Deprecated: use NewFromTemplate instead
+// Deprecated: use Create instead
 func NewWithAppCredential(ctx context.Context, m manipulate.Manipulator, template *gaia.AppCredential) (*gaia.AppCredential, error) {
-	fmt.Println("DEPRECATED: NewWithAppCredential is deprecated in favor of NewFromTemplate instead")
+	fmt.Println("DEPRECATED: NewWithAppCredential is deprecated in favor of Create instead")
 
 	csr, pk, err := makeCSR()
 	if err != nil {

--- a/appcreds/appcreds.go
+++ b/appcreds/appcreds.go
@@ -47,6 +47,7 @@ func NewWithAppCredential(ctx context.Context, m manipulate.Manipulator, templat
 	creds.Roles = template.Roles
 	creds.Protected = template.Protected
 	creds.Metadata = template.Metadata
+	creds.Annotations = template.Annotations
 	creds.AuthorizedSubnets = template.AuthorizedSubnets
 	creds.CSR = string(csr)
 

--- a/appcreds/appcreds.go
+++ b/appcreds/appcreds.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/pem"
+	"fmt"
 
 	"go.aporeto.io/gaia"
 	"go.aporeto.io/manipulate"
@@ -33,8 +34,32 @@ func New(ctx context.Context, m manipulate.Manipulator, namespace string, name s
 	return NewWithAppCredential(ctx, m, creds)
 }
 
+// NewFromTemplate generates a new CSR for the provided app credential and calls the upstream service using the supplied
+// manipulator to provision the app credential. The returned credential will have the private key used to generate the CSR
+// added back as an attribute. An error and a nil app cred reference is returned if CSR generation or the API call to the
+// upstream service failed.
+func NewFromTemplate(ctx context.Context, m manipulate.Manipulator, template *gaia.AppCredential) (*gaia.AppCredential, error) {
+
+	csr, pk, err := makeCSR()
+	if err != nil {
+		return nil, err
+	}
+
+	template.CSR = string(csr)
+
+	if err := m.Create(manipulate.NewContext(ctx, manipulate.ContextOptionNamespace(template.Namespace)), template); err != nil {
+		return nil, err
+	}
+
+	template.Credentials.CertificateKey = base64.StdEncoding.EncodeToString(pk)
+
+	return template, nil
+}
+
 // NewWithAppCredential creates a new *gaia.AppCredential from an *AppCredential
+// Deprecated: use NewFromTemplate instead
 func NewWithAppCredential(ctx context.Context, m manipulate.Manipulator, template *gaia.AppCredential) (*gaia.AppCredential, error) {
+	fmt.Println("DEPRECATED: NewWithAppCredential is deprecated in favor of NewFromTemplate instead")
 
 	csr, pk, err := makeCSR()
 	if err != nil {
@@ -47,7 +72,6 @@ func NewWithAppCredential(ctx context.Context, m manipulate.Manipulator, templat
 	creds.Roles = template.Roles
 	creds.Protected = template.Protected
 	creds.Metadata = template.Metadata
-	creds.Annotations = template.Annotations
 	creds.AuthorizedSubnets = template.AuthorizedSubnets
 	creds.CSR = string(csr)
 

--- a/appcreds/appcreds_test.go
+++ b/appcreds/appcreds_test.go
@@ -139,6 +139,10 @@ func TestAppCred_NewWithAppCredential(t *testing.T) {
 			template.Metadata = []string{"random=tag"}
 			template.Roles = []string{"role=test"}
 			template.Namespace = "/ns"
+			template.Annotations = map[string][]string{
+				"SomeKey1": {"SomeValue1"},
+				"SomeKey2": {"SomeValue2"},
+			}
 
 			c, err := NewWithAppCredential(context.Background(), m, template)
 
@@ -149,6 +153,7 @@ func TestAppCred_NewWithAppCredential(t *testing.T) {
 				So(c.Metadata, ShouldResemble, template.Metadata)
 				So(c.Roles, ShouldResemble, template.Roles)
 				So(c.Namespace, ShouldEqual, template.Namespace)
+				So(c.Annotations, ShouldResemble, template.Annotations)
 			})
 
 			Convey("Then err should be nil", func() {

--- a/appcreds/appcreds_test.go
+++ b/appcreds/appcreds_test.go
@@ -104,7 +104,7 @@ func TestAppCred_New(t *testing.T) {
 	})
 }
 
-func TestNewFromTemplate(t *testing.T) {
+func TestCreate(t *testing.T) {
 
 	Convey("Given I have a manipulator", t, func() {
 
@@ -130,7 +130,7 @@ func TestNewFromTemplate(t *testing.T) {
 			return nil
 		})
 
-		Convey("When I call NewWithAppCredential", func() {
+		Convey("When I call Create", func() {
 
 			template := gaia.NewAppCredential()
 			template.Name = "name"
@@ -144,7 +144,7 @@ func TestNewFromTemplate(t *testing.T) {
 				"SomeKey2": {"SomeValue2"},
 			}
 
-			c, err := NewFromTemplate(context.Background(), m, template)
+			c, err := Create(context.Background(), m, template)
 
 			Convey("Then credential should have template information", func() {
 				So(c.Name, ShouldEqual, template.Name)
@@ -201,7 +201,7 @@ func TestNewFromTemplate(t *testing.T) {
 			template.Roles = []string{"role=test"}
 			template.Namespace = "/ns"
 
-			c, err := NewFromTemplate(context.Background(), m, template)
+			c, err := Create(context.Background(), m, template)
 
 			Convey("Then err should not be nil", func() {
 				So(err, ShouldNotBeNil)


### PR DESCRIPTION
related to: https://github.com/aporeto-inc/aporeto/issues/1603

@primalmotion 