### PR TITLE
fixing proxy settings (#68)

### DIFF
--- a/apiutils/utils.go
+++ b/apiutils/utils.go
@@ -39,6 +39,7 @@ func GetServiceVersions(ctx context.Context, api string, tlsConfig *tls.Config) 
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}
@@ -72,6 +73,7 @@ func GetModelVersion(ctx context.Context, api string, tlsConfig *tls.Config) (*V
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}
@@ -105,6 +107,7 @@ func GetConfig(ctx context.Context, api string, tlsConfig *tls.Config) (map[stri
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}
@@ -138,6 +141,7 @@ func GetPublicCA(ctx context.Context, api string, tlsConfig *tls.Config) ([]byte
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}
@@ -183,6 +187,7 @@ func GetJWTCert(ctx context.Context, api string, tlsConfig *tls.Config) ([]byte,
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}
@@ -229,6 +234,7 @@ func GetManifestURL(ctx context.Context, api string, tlsConfig *tls.Config) ([]b
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}
@@ -256,6 +262,7 @@ func GetGoogleOAuthClientID(ctx context.Context, api string, tlsConfig *tls.Conf
 	client := &http.Client{
 		Timeout: 10 * time.Second,
 		Transport: &http.Transport{
+			Proxy:           http.ProxyFromEnvironment,
 			TLSClientConfig: tlsConfig,
 		},
 	}


### PR DESCRIPTION
Backport for 3.11 release branch which is what the 3.12 enforcer uses (pls don't ask me why - just trying to make a customer happy)