### PR TITLE
JWT segments are base64 URL encoded (RFC7519)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect
+	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/smartystreets/assertions v1.0.0

--- a/tokenutils/tokenutils.go
+++ b/tokenutils/tokenutils.go
@@ -48,7 +48,7 @@ func UnsecureClaimsMap(token string) (claims map[string]interface{}, err error) 
 		return nil, errors.New("invalid jwt: not enough segments")
 	}
 
-	data, err := base64.RawStdEncoding.DecodeString(parts[1])
+	data, err := base64.RawURLEncoding.DecodeString(parts[1])
 	if err != nil {
 		return nil, fmt.Errorf("invalid jwt: %s", err)
 	}
@@ -73,7 +73,7 @@ func SigAlg(token string) (string, error) {
 		return "", errors.New("invalid jwt: not enough segments")
 	}
 
-	data, err := base64.RawStdEncoding.DecodeString(parts[0])
+	data, err := base64.RawURLEncoding.DecodeString(parts[0])
 	if err != nil {
 		return "", fmt.Errorf("invalid jwt: %s", err)
 	}

--- a/tokenutils/tokenutils.go
+++ b/tokenutils/tokenutils.go
@@ -12,11 +12,12 @@
 package tokenutils
 
 import (
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
+
+	jwt "github.com/dgrijalva/jwt-go"
 )
 
 // Snip snips the given token from the given error.
@@ -48,7 +49,7 @@ func UnsecureClaimsMap(token string) (claims map[string]interface{}, err error) 
 		return nil, errors.New("invalid jwt: not enough segments")
 	}
 
-	data, err := base64.RawURLEncoding.DecodeString(parts[1])
+	data, err := jwt.DecodeSegment(parts[1])
 	if err != nil {
 		return nil, fmt.Errorf("invalid jwt: %s", err)
 	}
@@ -73,7 +74,7 @@ func SigAlg(token string) (string, error) {
 		return "", errors.New("invalid jwt: not enough segments")
 	}
 
-	data, err := base64.RawURLEncoding.DecodeString(parts[0])
+	data, err := jwt.DecodeSegment(parts[0])
 	if err != nil {
 		return "", fmt.Errorf("invalid jwt: %s", err)
 	}

--- a/tokenutils/tokenutils_test.go
+++ b/tokenutils/tokenutils_test.go
@@ -128,19 +128,37 @@ func TestTokenUtils_UnsecureClaimsMap(t *testing.T) {
 
 	Convey("Given I have a token a token with invalid base64", t, func() {
 
-		token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.not-base64.jvh034mNSV-Fy--GIGnnYeWouluV6CexC9_8IHJ-IR4"
+		token := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.XXX.jvh034mNSV-Fy--GIGnnYeWouluV6CexC9_8IHJ-IR4"
+
+		Convey("When I UnsecureClaimsMap", func() {
+
+			claims, err := UnsecureClaimsMap(token)
+
+			Convey("Then err should not be nil", func() {
+				So(err, ShouldNotBeNil)
+				So(err.Error(), ShouldEqual, "invalid jwt: invalid character ']' looking for beginning of value")
+			})
+
+			Convey("Then claims should be nil", func() {
+				So(claims, ShouldBeNil)
+			})
+		})
+	})
+
+	Convey("Given I have a token a token with valid base64 URL", t, func() {
+
+		token := "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.ew0KICAicmVhbG0iOiAiPz8_Pz8_Ig0KfQ0KDQo.hJwIQMyvQ1-VqfImMnaNYDPq6uxy8fscLLVji9loOW9OrPLZfqqfMxrg0tko9CPLxoB4wG3_KWshPPeyUBUspQ"
 
 		Convey("When I UnsecureClaimsMap", func() {
 
 			claims, err := UnsecureClaimsMap(token)
 
 			Convey("Then err should be nil", func() {
-				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "invalid jwt: illegal base64 data at input byte 3")
+				So(err, ShouldBeNil)
 			})
 
-			Convey("Then claims should be nil", func() {
-				So(claims, ShouldBeNil)
+			Convey("Then claims should not be nil", func() {
+				So(claims, ShouldNotBeNil)
 			})
 		})
 	})
@@ -225,15 +243,15 @@ func TestJWTUtils_SigAlg(t *testing.T) {
 
 	Convey("Given I have a token a token with invalid base64", t, func() {
 
-		token := "not-base-64.eyJyZWFsbSI6IlZpbmNlIiwiZGF0YSI6eyJhY2NvdW50IjoiYXBvbXV4IiwiZW1haWwiOiJhZG1pbkBhcG9tdXguY29tIiwiaWQiOiI1YTZhNTUxMTdkZGYxZjIxMmY4ZWIwY2UiLCJvcmdhbml6YXRpb24iOiJhcG9tdXgiLCJyZWFsbSI6InZpbmNlIn0sImF1ZCI6ImFwb3JldG8uY29tIiwiZXhwIjoxNTIwNjQ5MTAyLCJpYXQiOjE1MTgwNTcxMDIsImlzcyI6Im1pZGdhcmQuYXBvbXV4LmNvbSIsInN1YiI6ImFwb211eCJ9.jvh034mNSV-Fy--GIGnnYeWouluV6CexC9_8IHJ-IR4"
+		token := "XXX.eyJyZWFsbSI6IlZpbmNlIiwiZGF0YSI6eyJhY2NvdW50IjoiYXBvbXV4IiwiZW1haWwiOiJhZG1pbkBhcG9tdXguY29tIiwiaWQiOiI1YTZhNTUxMTdkZGYxZjIxMmY4ZWIwY2UiLCJvcmdhbml6YXRpb24iOiJhcG9tdXgiLCJyZWFsbSI6InZpbmNlIn0sImF1ZCI6ImFwb3JldG8uY29tIiwiZXhwIjoxNTIwNjQ5MTAyLCJpYXQiOjE1MTgwNTcxMDIsImlzcyI6Im1pZGdhcmQuYXBvbXV4LmNvbSIsInN1YiI6ImFwb211eCJ9.jvh034mNSV-Fy--GIGnnYeWouluV6CexC9_8IHJ-IR4"
 
 		Convey("When I SigAlg", func() {
 
 			alg, err := SigAlg(token)
 
-			Convey("Then err should be nil", func() {
+			Convey("Then err should not be nil", func() {
 				So(err, ShouldNotBeNil)
-				So(err.Error(), ShouldEqual, "invalid jwt: illegal base64 data at input byte 3")
+				So(err.Error(), ShouldEqual, "invalid jwt: invalid character ']' looking for beginning of value")
 			})
 
 			Convey("Then alg should be empty", func() {


### PR DESCRIPTION
As per https://tools.ietf.org/html/rfc7519 JWT segment are base64 URL encoded (https://tools.ietf.org/html/rfc4648#section-5) so they are safe to be used on URL.

Previously we were just decoding as plain base64 which lead to decoding error if the token received contains _ char for instance.

https://github.com/dgrijalva/jwt-go.git used to create JWT is already encoding in base64 URL variation so only the "unsecure" decoding was impacted.